### PR TITLE
Update verification.java (compilation error)

### DIFF
--- a/verification.java
+++ b/verification.java
@@ -4,7 +4,7 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
 Mac mac = Mac.getInstance("HmacSHA256");
-String secret = System.getenv("CHAMELEON_VERIFICATION_SECRET").getBytes("UTF-8");
+byte[] secret = System.getenv("CHAMELEON_VERIFICATION_SECRET").getBytes("UTF-8");
 SecretKeySpec secretKeySpec = new SecretKeySpec(secret, "HmacSHA256");
 mac.init(secretKeySpec);
 


### PR DESCRIPTION
`getBytes()` doesn’t return a String, it returns a byte array.

It would be nice if someone at Chameleon were actually running this code, or even looking at it in a compiler. There are multiple ways this code doesn’t compile when `secret` is a String.