### PR TITLE
Update verification.java (incorrect hash)

### DIFF
--- a/verification.java
+++ b/verification.java
@@ -9,7 +9,7 @@ SecretKeySpec secretKeySpec = new SecretKeySpec(secret, "HmacSHA256");
 mac.init(secretKeySpec);
 
 String now = String.valueOf(System.currentTimeMillis() / 1000L);
-String uid_hash = String.format("%032x", new BigInteger(1, mac.doFinal((uid + "-" + now).getBytes("UTF-8")))) + "-" + now;
+String uid_hash = String.format("%064x", new BigInteger(1, mac.doFinal((uid + "-" + now).getBytes("UTF-8")))) + "-" + now;
 
 //
 // send back the `uid_hash` along side `uid` and add to the existing `chmln.identify(uid, { uid_hash: uid_hash })`


### PR DESCRIPTION
This sample code produces incorrect hash strings in certain cases. There are cases when converting the HMAC hash to hex will give you 63 characters. You expect these hex strings to be 64 characters, so you want those strings to start with a "0".

But your `String.format` call is zero-padding to 32 characters, not 64, so this code will happily spit out a 63-character hashed string (minus the time obviously), which you will never accept.